### PR TITLE
Adding `gulpplugin` keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "template",
     "precompilation",
     "gulp",
-    "plugin"
+    "plugin",
+    "gulpplugin"
   ],
   "author": "Constantin Titarenko",
   "license": "MIT",


### PR DESCRIPTION
Adding `gulpplugin` keyword so it gets listed in http://gulpjs.com/plugins/
