### PR TITLE
Fix #2 - Improve getTemplateName

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function getTemplateName(root, name, extension, separator) {
     //clean possible leading dots
     relativeName = relativeName.replace('../', '');
     //remove extension
-    relativeName = path.basename(relativeName, extension);
+    relativeName = path.join(path.dirname(relativeName),path.basename(relativeName, extension));
     //return new template name with separator
     return relativeName.replace('/', separator);
 }

--- a/index.js
+++ b/index.js
@@ -8,12 +8,14 @@ var PluginError = gutil.PluginError;
 const PLUGIN_NAME = 'gulp-dotify';
 
 function getTemplateName(root, name, extension, separator) {
-	var parts = name.split(path.sep);
-	var i = parts.indexOf(root);
-	parts = parts.slice(i + 1);
-	i = parts.length - 1;
-	parts[i] = path.basename(parts[i], extension);
-	return parts.join(separator);
+    //get relative name from root to name
+    var relativeName = path.relative(root, name);
+    //get old extname (mainly for length)
+    var oldExt = path.extname(relativeName);
+    //now remove it and add the new one
+    relativeName = relativeName.slice(0, (-oldExt.length || relativeName.length)) + extension;
+    //return new template name with separator
+    return relativeName.replace('/', separator);
 }
 
 function getTemplateCode(content) {
@@ -64,6 +66,6 @@ function gulpDotify(options) {
 		}
 	});
 	return stream;
-};
+}
 
 module.exports = gulpDotify;

--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ const PLUGIN_NAME = 'gulp-dotify';
 
 function getTemplateName(root, name, extension, separator) {
     //get relative name from root to name
-    var relativeName = path.relative(root, name);
-    //get old extname (mainly for length)
-    var oldExt = path.extname(relativeName);
-    //now remove it and add the new one
-    relativeName = relativeName.slice(0, (-oldExt.length || relativeName.length)) + extension;
+    var relativeName = path.normalize(path.relative(root, name));
+    //clean possible leading dots
+    relativeName = relativeName.replace('../', '');
+    //remove extension
+    relativeName = path.basename(relativeName, extension);
     //return new template name with separator
     return relativeName.replace('/', separator);
 }


### PR DESCRIPTION
Improve getTemplateName to handle:
1. smarter paths - uses relative
2. root with inner directories
3. handle extension name better
